### PR TITLE
Add the blink utility function

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ enum mgos_app_init_result mgos_app_init(void) {
   mgos_pcf857x_gpio_set_button_handler(d, 2, MGOS_GPIO_PULL_UP, MGOS_GPIO_INT_EDGE_ANY, 10, button_cb, d);
   mgos_pcf857x_gpio_set_button_handler(d, 3, MGOS_GPIO_PULL_UP, MGOS_GPIO_INT_EDGE_ANY, 10, button_cb, d);
 
+  mgos_pcf857x_gpio_blink(d, 4, 1000, 1000);
+
   return MGOS_APP_INIT_SUCCESS;
 }
 ```

--- a/include/mgos_pcf857x.h
+++ b/include/mgos_pcf857x.h
@@ -18,12 +18,15 @@
 #include "mgos.h"
 #include "mgos_gpio.h"
 #include "mgos_i2c.h"
+#include "mgos_timers.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct mgos_pcf857x;
+
+struct mgos_pcf857x_gpio_blink_state;
 
 /*
  * Initialize a PCF857X on the I2C bus `i2c` at address specified in `i2caddr`
@@ -62,6 +65,14 @@ bool mgos_pcf857x_gpio_disable_int(struct mgos_pcf857x *dev, int pin);
 void mgos_pcf857x_gpio_clear_int(struct mgos_pcf857x *dev, int pin);
 void mgos_pcf857x_gpio_remove_int_handler(struct mgos_pcf857x *dev, int pin, mgos_gpio_int_handler_f *old_cb, void **old_arg);
 bool mgos_pcf857x_gpio_set_button_handler(struct mgos_pcf857x *dev, int pin, enum mgos_gpio_pull_type pull_type, enum mgos_gpio_int_mode int_mode, int debounce_ms, mgos_gpio_int_handler_f cb, void *arg);
+
+/*
+ * A utility function that takes care of blinking an LED.
+ * The pin must be configured as output first.
+ * Set to (0, 0) to disable.
+ */
+bool mgos_pcf857x_gpio_blink(struct mgos_pcf857x *dev, int pin, int on_ms, int off_ms);
+void mgos_pcf857x_gpio_blink_cb(void *arg);
 
 #ifdef __cplusplus
 }

--- a/include/mgos_pcf857x.h
+++ b/include/mgos_pcf857x.h
@@ -18,7 +18,6 @@
 #include "mgos.h"
 #include "mgos_gpio.h"
 #include "mgos_i2c.h"
-#include "mgos_timers.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mgos_pcf857x.h
+++ b/include/mgos_pcf857x.h
@@ -66,7 +66,6 @@ bool mgos_pcf857x_gpio_set_button_handler(struct mgos_pcf857x *dev, int pin, enu
 
 /*
  * A utility function that takes care of blinking an LED.
- * The pin must be configured as output first.
  * Set to (0, 0) to disable.
  */
 bool mgos_pcf857x_gpio_blink(struct mgos_pcf857x *dev, int pin, int on_ms, int off_ms);

--- a/include/mgos_pcf857x.h
+++ b/include/mgos_pcf857x.h
@@ -26,8 +26,6 @@ extern "C" {
 
 struct mgos_pcf857x;
 
-struct mgos_pcf857x_gpio_blink_state;
-
 /*
  * Initialize a PCF857X on the I2C bus `i2c` at address specified in `i2caddr`
  * parameter (default PCF857X is on address 0x20). The device will be polled for
@@ -72,7 +70,6 @@ bool mgos_pcf857x_gpio_set_button_handler(struct mgos_pcf857x *dev, int pin, enu
  * Set to (0, 0) to disable.
  */
 bool mgos_pcf857x_gpio_blink(struct mgos_pcf857x *dev, int pin, int on_ms, int off_ms);
-void mgos_pcf857x_gpio_blink_cb(void *arg);
 
 #ifdef __cplusplus
 }

--- a/include/mgos_pcf857x.h
+++ b/include/mgos_pcf857x.h
@@ -65,7 +65,7 @@ bool mgos_pcf857x_gpio_set_button_handler(struct mgos_pcf857x *dev, int pin, enu
 
 /*
  * A utility function that takes care of blinking an LED.
- * Set to (0, 0) to disable.
+ * Set either on_ms or off_ms to 0 to disable
  */
 bool mgos_pcf857x_gpio_blink(struct mgos_pcf857x *dev, int pin, int on_ms, int off_ms);
 

--- a/src/mgos_pcf857x.c
+++ b/src/mgos_pcf857x.c
@@ -36,6 +36,13 @@ static struct mgos_pcf857x_gpio_blink_state *mgos_pcf857x_get_or_create_blink_st
   return blink_states[pin];
 }
 
+static void mgos_pcf857x_clear_blink_state(int pin) {
+  if(blink_states[pin] != NULL) {
+    free(blink_states[pin]);
+    blink_states[pin] = NULL;
+  }
+}
+
 void mgos_pcf857x_print_state(struct mgos_pcf857x *dev) {
   uint8_t n;
   char    s[17], i[17];
@@ -405,6 +412,8 @@ bool mgos_pcf857x_gpio_blink(struct mgos_pcf857x *dev, int pin, int on_ms, int o
             mgos_pcf857x_gpio_blink_cb, bs);
         res = (bs->timer_id != MGOS_INVALID_TIMER_ID);
         LD("Set timer for PIN-%d (on=%dms, off=%dms)", bs->pin, bs->on_ms, bs->off_ms);
+      } else if(on_ms == 0 && off_ms == 0) {
+        mgos_pcf857x_clear_blink_state(bs->pin);
       }
     }
   }

--- a/src/mgos_pcf857x.c
+++ b/src/mgos_pcf857x.c
@@ -381,7 +381,7 @@ bool mgos_pcf857x_gpio_set_button_handler(struct mgos_pcf857x *dev, int pin, enu
   (void)pull_type;
 }
 
-void mgos_pcf857x_gpio_blink_cb(void *arg) {
+static void mgos_pcf857x_gpio_blink_cb(void *arg) {
   struct mgos_pcf857x_gpio_blink_state *bs = (struct mgos_pcf857x_gpio_blink_state *)arg;
 
   if (bs != NULL) {

--- a/src/mgos_pcf857x.c
+++ b/src/mgos_pcf857x.c
@@ -20,7 +20,7 @@
 
 static struct mgos_pcf857x_gpio_blink_state **blink_states = NULL;
 
-struct mgos_pcf857x_gpio_blink_state *mgos_pcf857x_get_or_create_blink_state(struct mgos_pcf857x *dev, int pin) {
+static struct mgos_pcf857x_gpio_blink_state *mgos_pcf857x_get_or_create_blink_state(struct mgos_pcf857x *dev, int pin) {
   if (blink_states == NULL) {
     blink_states = calloc(dev->num_gpios, sizeof(struct mgos_pcf857x_gpio_blink_state *));
     LD("Init %d pin", dev->num_gpios);

--- a/src/mgos_pcf857x.c
+++ b/src/mgos_pcf857x.c
@@ -30,7 +30,7 @@ static struct mgos_pcf857x_gpio_blink_state *mgos_pcf857x_get_or_create_blink_st
     blink_states[pin] = calloc(1, sizeof(struct mgos_pcf857x_gpio_blink_state));
     blink_states[pin]->dev = dev;
     blink_states[pin]->pin = pin;
-    blink_states[pin]->blink.timer_id = MGOS_INVALID_TIMER_ID;
+    blink_states[pin]->timer_id = MGOS_INVALID_TIMER_ID;
   }
 
   return blink_states[pin];
@@ -377,9 +377,9 @@ void mgos_pcf857x_gpio_blink_cb(void *arg) {
 
   if (bs != NULL) {
     bool curr = mgos_pcf857x_gpio_toggle(bs->dev, bs->pin);
-    if (bs->blink.on_ms != bs->blink.off_ms) {
-      int timeout = (curr ? bs->blink.on_ms : bs->blink.off_ms);
-      bs->blink.timer_id = mgos_set_timer(timeout, 0, mgos_pcf857x_gpio_blink_cb, bs);
+    if (bs->on_ms != bs->off_ms) {
+      int timeout = (curr ? bs->on_ms : bs->off_ms);
+      bs->timer_id = mgos_set_timer(timeout, 0, mgos_pcf857x_gpio_blink_cb, bs);
     }
   }
 }
@@ -390,21 +390,21 @@ bool mgos_pcf857x_gpio_blink(struct mgos_pcf857x *dev, int pin, int on_ms, int o
     struct mgos_pcf857x_gpio_blink_state *bs = mgos_pcf857x_get_or_create_blink_state(dev, pin);
     if (bs != NULL) {
 
-      bs->blink.on_ms = on_ms;
-      bs->blink.off_ms = off_ms;
+      bs->on_ms = on_ms;
+      bs->off_ms = off_ms;
 
-      if (bs->blink.timer_id != MGOS_INVALID_TIMER_ID) {
-        mgos_clear_timer(bs->blink.timer_id);
-        bs->blink.timer_id = MGOS_INVALID_TIMER_ID;
+      if (bs->timer_id != MGOS_INVALID_TIMER_ID) {
+        mgos_clear_timer(bs->timer_id);
+        bs->timer_id = MGOS_INVALID_TIMER_ID;
         LD("Clear timer for PIN-%d", bs->pin);
       }
       if (on_ms != 0 && off_ms != 0) {
-        bs->blink.timer_id = mgos_set_timer(
+        bs->timer_id = mgos_set_timer(
             on_ms,
             (on_ms == off_ms ? MGOS_TIMER_REPEAT : 0) | MGOS_TIMER_RUN_NOW,
             mgos_pcf857x_gpio_blink_cb, bs);
-        res = (bs->blink.timer_id != MGOS_INVALID_TIMER_ID);
-        LD("Set timer for PIN-%d (on=%dms, off=%dms)", bs->pin, bs->blink.on_ms, bs->blink.off_ms);
+        res = (bs->timer_id != MGOS_INVALID_TIMER_ID);
+        LD("Set timer for PIN-%d (on=%dms, off=%dms)", bs->pin, bs->on_ms, bs->off_ms);
       }
     }
   }

--- a/src/mgos_pcf857x.c
+++ b/src/mgos_pcf857x.c
@@ -31,6 +31,8 @@ static struct mgos_pcf857x_gpio_blink_state *mgos_pcf857x_get_or_create_blink_st
     blink_states[pin]->dev = dev;
     blink_states[pin]->pin = pin;
     blink_states[pin]->timer_id = MGOS_INVALID_TIMER_ID;
+    
+    mgos_pcf857x_gpio_setup_output(dev, pin, false);
   }
 
   return blink_states[pin];

--- a/src/mgos_pcf857x.c
+++ b/src/mgos_pcf857x.c
@@ -414,7 +414,7 @@ bool mgos_pcf857x_gpio_blink(struct mgos_pcf857x *dev, int pin, int on_ms, int o
             mgos_pcf857x_gpio_blink_cb, bs);
         res = (bs->timer_id != MGOS_INVALID_TIMER_ID);
         LD("Set timer for PIN-%d (on=%dms, off=%dms)", bs->pin, bs->on_ms, bs->off_ms);
-      } else if(on_ms == 0 && off_ms == 0) {
+      } else {
         mgos_pcf857x_clear_blink_state(bs->pin);
       }
     }

--- a/src/mgos_pcf857x_internal.h
+++ b/src/mgos_pcf857x_internal.h
@@ -46,6 +46,16 @@ struct mgos_pcf857x {
   struct mgos_pcf857x_cb cb[16];
 };
 
+struct mgos_pcf857x_gpio_blink_state {
+  int pin;
+  struct mgos_pcf857x *dev;
+  struct {
+    unsigned int on_ms;
+    unsigned int off_ms;
+    mgos_timer_id timer_id;
+  } blink;
+};
+
 /* Mongoose OS initializer */
 bool mgos_pcf857x_i2c_init(void);
 

--- a/src/mgos_pcf857x_internal.h
+++ b/src/mgos_pcf857x_internal.h
@@ -49,11 +49,9 @@ struct mgos_pcf857x {
 struct mgos_pcf857x_gpio_blink_state {
   int pin;
   struct mgos_pcf857x *dev;
-  struct {
-    unsigned int on_ms;
-    unsigned int off_ms;
-    mgos_timer_id timer_id;
-  } blink;
+  unsigned int on_ms;
+  unsigned int off_ms;
+  mgos_timer_id timer_id;
 };
 
 /* Callback used by the blink function */

--- a/src/mgos_pcf857x_internal.h
+++ b/src/mgos_pcf857x_internal.h
@@ -56,7 +56,7 @@ struct mgos_pcf857x_gpio_blink_state {
 };
 
 /* Callback used by the blink function */
-void mgos_pcf857x_gpio_blink_cb(void *arg);
+static void mgos_pcf857x_gpio_blink_cb(void *arg);
 
 /* Mongoose OS initializer */
 bool mgos_pcf857x_i2c_init(void);

--- a/src/mgos_pcf857x_internal.h
+++ b/src/mgos_pcf857x_internal.h
@@ -56,6 +56,9 @@ struct mgos_pcf857x_gpio_blink_state {
   } blink;
 };
 
+/* Callback used by the blink function */
+static void mgos_pcf857x_gpio_blink_cb(void *arg);
+
 /* Mongoose OS initializer */
 bool mgos_pcf857x_i2c_init(void);
 

--- a/src/mgos_pcf857x_internal.h
+++ b/src/mgos_pcf857x_internal.h
@@ -16,6 +16,7 @@
 
 #pragma once
 #include "mgos_pcf857x.h"
+#include "mgos_timers.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/mgos_pcf857x_internal.h
+++ b/src/mgos_pcf857x_internal.h
@@ -56,7 +56,7 @@ struct mgos_pcf857x_gpio_blink_state {
 };
 
 /* Callback used by the blink function */
-static void mgos_pcf857x_gpio_blink_cb(void *arg);
+void mgos_pcf857x_gpio_blink_cb(void *arg);
 
 /* Mongoose OS initializer */
 bool mgos_pcf857x_i2c_init(void);


### PR DESCRIPTION
The PR resolves #2 by adding the blink utility function. The pin must be configured as output first.